### PR TITLE
🚿 Add scan-build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,4 @@ services:
   - docker
 
 script:
-  - docker build -t xxd-test .
-  - docker run -e "TRAVIS_JOB_ID=$TRAVIS_JOB_ID" --security-opt seccomp:unconfined xxd-test
+  - cd $TRAVIS_BUILD_DIR && ./tests.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM ubuntu:cosmic
 
-RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
   binutils-dev \
   build-essential \
+  clang-7 \
+  clang-tools-7 \
   cmake \
   curl \
   g++ \
@@ -30,9 +31,4 @@ RUN bash -c "cd /tmp && \
 
 COPY . /tmp/xxd-test
 
-CMD bash -c \
-  "cd /tmp/xxd-test && \
-  make -j6 && \
-  make clean && \
-  DISABLE_LIBASAN=y make xxd -j6 && \
-  kcov --coveralls-id=$TRAVIS_JOB_ID kcov-output --include-path=/tmp/xxd-test/xxd.c ./xxd xxd.c"
+CMD bash -c "cd /tmp/xxd-test && make -j6"

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ test: xxd | testinput/* xxd.c README.md
 	$(call violettext,Running tests...)
 	echo -n $| | xargs -t -d " " -I % bash -c "diff -du <(xxd %) <(./xxd %)"
 	echo -n $| | xargs -t -d " " -I % bash -c "diff -du <(xxd -c 8 %) <(./xxd % 8)"
+	echo -n $| | xargs -t -d " " -I % bash -c "diff -du <(xxd -c 0 %) <(./xxd % 0)"
 	$(call greentext,All tests passed!)
 
 xxd: main.c xxd.c

--- a/README.md
+++ b/README.md
@@ -3,3 +3,40 @@
 
 # 👻 xxd
 Stunt / code golf, got out of hand.
+
+# usage
+Copy `xxd.c` + `xxd.h` into your project, or copy the contents of `xxd.c`.
+
+# build standalone
+Use docker..
+## docker quickstart
+On ubuntu as easy as:
+```bash
+# install docker
+sudo apt install docker.io
+# add your user to the 'docker' group to avoid needing sudo
+sudo usermod -aG docker $USER
+newgrp docker
+# log out and back in so usermod takes effect
+```
+
+## run
+You can run exactly what CI does by doing:
+```bash
+./tests.sh
+```
+
+## run more
+If you want to run the steps manually-
+```bash
+docker build -t xxd-test .
+
+# on build, the image copies the current working dir into /tmp/xxd-test for CI
+# to use, so note that your changes won't be propogated without rebuilding.
+# --cap-add SYS_PTRACE is for address sanitizer
+docker run --cap-add SYS_PTRACE xxd-test
+
+# you can optionally just bind mount the current dir if you're making mods:
+docker run --cap-add SYS_PTRACE -v "$(pwd):/tmp/xxd-test" xxd-test
+# that will write build output into the cwd though so be aware.
+```

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -ex
+
+# All the steps run by CI. Should work locally too!
+docker build -t xxd-test .
+
+# run scan-build
+docker run xxd-test bash -c \
+    "cd /tmp/xxd-test && \
+     DISABLE_LIBASAN=y CC=clang-7 scan-build-7 --status-bugs make"
+
+# run default build command
+docker run --cap-add SYS_PTRACE xxd-test
+
+# run full build, including kcov coverage upload
+docker run --cap-add SYS_PTRACE -e "TRAVIS_JOB_ID=$TRAVIS_JOB_ID" \
+    --security-opt seccomp:unconfined xxd-test bash -c \
+    "cd /tmp/xxd-test && \
+     DISABLE_LIBASAN=y make xxd && \
+     kcov --coveralls-id=$TRAVIS_JOB_ID kcov-output --include-path=/tmp/xxd-test/xxd.c ./xxd xxd.c"

--- a/xxd.c
+++ b/xxd.c
@@ -6,6 +6,9 @@
 
 // print xxd yo
 void xxd(const void *buf, size_t len, size_t xxd_width) {
+  if (!xxd_width) {
+    xxd_width = 16;
+  }
   for (size_t addr = 0; addr < len; addr += xxd_width) {
     uint8_t *linedata = (uint8_t *)buf + addr;
     const size_t linelen =


### PR DESCRIPTION
Add scan-build (and clang build), no sanitizer support enabled for that
yet though.

Change behavior when xxd_width=0 (for canonical xxd, that uses
default=16).

Rework Dockerfile default CMD to be simpler.

Move build commands into `tests.sh` to make it easy to run locally.