### PR TITLE
Noahp/coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,7 @@
 *.o
 *.out
 xxd
-kcov-output/
+coverage/
+*.info
+*.gcda
+*.gcno

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ services:
   - docker
 
 script:
-  - cd $TRAVIS_BUILD_DIR && ./tests.sh
+  - cd $TRAVIS_BUILD_DIR && COVERALLS_UPLOAD=1 ./tests.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,19 @@
 FROM ubuntu:cosmic
 
 RUN apt-get update && apt-get install -y \
-  binutils-dev \
   build-essential \
   clang-7 \
   clang-tools-7 \
-  cmake \
   curl \
-  g++ \
   gcc \
   git \
-  libcurl4-openssl-dev \
-  libdw-dev \
-  libiberty-dev \
+  lcov \
+  pkg-config \
   python \
-  wget \
-  xxd \
-  zlib1g-dev
+  python-pip \
+  xxd
 
-# get kcov
-RUN bash -c "cd /tmp && \
-  wget https://github.com/SimonKagstrom/kcov/archive/v36.tar.gz && \
-  tar xzf v*.tar.gz && \
-  cd kcov-* && \
-  mkdir build && \
-  cd build && \
-  cmake ../ && \
-  make -j6 && \
-  make install"
+RUN pip install cpp-coveralls
 
 COPY . /tmp/xxd-test
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,13 @@ ifeq ($(DISABLE_LIBASAN),)
   CFLAGS += -fsanitize=address -fsanitize=undefined -fstack-usage -static-libasan
 endif
 
+ifeq ($(XXD_COVERAGE),1)
+CFLAGS += --coverage
+
+# Set LCOV if available
+LCOV ?=
+endif
+
 # colored output ^_^ https://gist.github.com/chrisopedia/8754917
 textviolet=$(shell echo "\033[1;95m")
 textgreen=$(shell echo "\033[1;92m")
@@ -30,6 +37,15 @@ test: xxd | testinput/* xxd.c README.md
 	echo -n $| | xargs -t -d " " -I % bash -c "diff -du <(xxd -c 8 %) <(./xxd % 8)"
 	echo -n $| | xargs -t -d " " -I % bash -c "diff -du <(xxd -c 0 %) <(./xxd % 0)"
 	$(call greentext,All tests passed!)
+ifeq ($(XXD_COVERAGE),1)
+ifdef LCOV
+	@echo "+++ Running lcov..."
+	$(LCOV) --quiet --rc lcov_branch_coverage=1 --capture --directory ./ --output-file coverage.info
+	$(LCOV) --quiet --rc lcov_branch_coverage=1 --remove coverage.info "*main.c" -o coverage_filtered.info
+	genhtml --branch-coverage coverage_filtered.info --output-directory coverage
+	@echo "See file://$(abspath coverage)/index.html for lcov results"
+endif
+endif
 
 xxd: main.c xxd.c
 	$(call violettext,Building...)

--- a/xxd.c
+++ b/xxd.c
@@ -6,7 +6,7 @@
 
 // print xxd yo
 void xxd(const void *buf, size_t len, size_t xxd_width) {
-  if (!xxd_width) {
+  if (!xxd_width || xxd_width > 16) {
     xxd_width = 16;
   }
   for (size_t addr = 0; addr < len; addr += xxd_width) {
@@ -14,9 +14,9 @@ void xxd(const void *buf, size_t len, size_t xxd_width) {
     const size_t linelen =
         (addr + xxd_width < len) ? (xxd_width) : (len - addr);
 
-    char outbuf[strlen("xxxx ") * xxd_width / 2 + xxd_width];
+    char outbuf[strlen("xxxx ") * 16 / 2 + 16];
     outbuf[0] = '\0';
-    char asciibuf[xxd_width * 2 + 1];
+    char asciibuf[16 * 2 + 1];
 
     // load hex format
     for (size_t i = 0; i < xxd_width; i++) {


### PR DESCRIPTION
Add coveralls and codecov support, enable coveralls now (soon to switch to codecov).
Also switch from kcov to lcov for branch coverage (todo: look into clang coverage analysis, it seems interesting!).